### PR TITLE
chore: serialization for release info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
 ] }
 semver = "1.0.22"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tar = "0.4.40"
 thiserror = "1.0.49"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ use async_trait::async_trait;
 use lazy_static::lazy_static;
 use reqwest::Client;
 use semver::Version;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::env::consts::{ARCH, OS};
@@ -77,7 +78,7 @@ lazy_static! {
     };
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum Platform {
     LinuxMusl,
     LinuxMuslAarch64,
@@ -136,7 +137,7 @@ impl fmt::Display for ArchiveType {
 pub type ProgressCallback = dyn Fn(u64, u64) + Send + Sync;
 
 /// Information about a specific binary in a release, including its version and SHA256 hash.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct BinaryInfo {
     pub name: String,
     pub version: String,
@@ -144,14 +145,14 @@ pub struct BinaryInfo {
 }
 
 /// Collection of binaries for a specific platform.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct PlatformBinaries {
     pub platform: Platform,
     pub binaries: Vec<BinaryInfo>,
 }
 
 /// Release information from the maidsafe/autonomi GitHub repository.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct AutonomiReleaseInfo {
     pub commit_hash: String,
     pub name: String,

--- a/tests/test_autonomi_release_info.rs
+++ b/tests/test_autonomi_release_info.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 MaidSafe.net limited.
+// Copyright (C) 2025 MaidSafe.net limited.
 //
 // This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
 // Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed


### PR DESCRIPTION
As part of our automated-upgrades process we are going to cache the release information to disk, and therefore we need to support serialization on these types.